### PR TITLE
Bump version and standardize API meta

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """NX AI - FastAPI/Python/Postgres/tsvector"""
 
 # Current Version
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/app/api/products.py
+++ b/app/api/products.py
@@ -39,11 +39,11 @@ def root() -> dict:
 
     epoch = int(time.time() * 1000)
     meta = {
+        "title": "Product List",
+        "description": "from the products Postgres table",
         "version": __version__,
         "base_url": base_url,
-        "time": time.strftime('%Y-%m-%d %H:%M:%S', time.localtime()),
-        "epoch": epoch,
+        "time": epoch,
         "severity": "success",
-        "message": f"{len(products)} products"
     }
     return {"meta": meta, "data": products}

--- a/app/api/root.py
+++ b/app/api/root.py
@@ -13,12 +13,12 @@ def root() -> dict:
     base_url = os.getenv("BASE_URL", "http://localhost:8000")
     epoch = int(time.time() * 1000)
     meta = {
-        "base_url": base_url,
+        "title": "NX-AI says hi",
+        "description": "This is the base_url",
         "version": __version__,
-        "time": time.strftime('%Y-%m-%d %H:%M:%S', time.localtime()),
-        "epoch": epoch,
+        "base_url": base_url,
+        "time": epoch,
         "severity": "success",
-        "message": f"NX AI says hello",
     }
     endpoints = [
         {"docs": "docs", "url": f"{base_url}/docs"},


### PR DESCRIPTION
Upgrade package version to 1.0.7 and normalize API response metadata across endpoints. Both root and products endpoints now include title and description fields, use an epoch millisecond timestamp for "time", and reorganize base_url placement; extraneous human-readable message fields were removed. Files changed: app/__init__.py, app/api/root.py, app/api/products.py.