### PR TITLE
Add make_meta util and update products API

### DIFF
--- a/app/api/products/products.py
+++ b/app/api/products/products.py
@@ -1,5 +1,6 @@
 
 from app import __version__
+from app.utils.make_meta import make_meta
 from fastapi import APIRouter
 import os, time
 from app.api.db import get_db_connection
@@ -21,13 +22,5 @@ def root() -> dict:
     cur.close()
     conn.close()
 
-    base_url = os.getenv("BASE_URL", "http://localhost:8000")
-    epoch = int(time.time() * 1000)
-    meta = {
-        "severity": "success",
-        "title": "Product List",
-        "version": __version__,
-        "base_url": base_url,
-        "time": epoch,
-    }
+    meta = make_meta("success", "Product List")
     return {"meta": meta, "data": products}

--- a/app/api/products/update.py
+++ b/app/api/products/update.py
@@ -2,58 +2,14 @@ from fastapi import APIRouter, status
 import os, csv, time
 from app.api.db import get_db_connection
 from app import __version__
+from app.utils.make_meta import make_meta
 
 router = APIRouter()
 
 @router.get("/products/update", status_code=status.HTTP_202_ACCEPTED)
-def update_products() -> dict:
-    """Process the large big_data.csv file to update products."""
-    csv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data/big_data.csv'))
-    process_csv(csv_path)
-    base_url = os.getenv("BASE_URL", "http://localhost:8000")
-    epoch = int(time.time() * 1000)
-    meta = {
-        "severity": "info",
-        "title": "Product update from big_data.csv started",
-        "version": __version__,
-        "base_url": base_url,
-        "time": epoch,
-    }
-    return {"meta": meta, "data": {"filename": "big_data.csv"}}
 
-def process_csv(csv_path: str):
-    conn_gen = get_db_connection()
-    conn = next(conn_gen)
-    cur = conn.cursor()
-    with open(csv_path, newline='') as csvfile:
-        reader = csv.DictReader(csvfile)
-        for row in reader:
-            cur.execute(
-                """
-                UPDATE product SET
-                    Params=%(Params)s,
-                    title=%(desc)s,
-                    UOS=%(UOS)s,
-                    Pack_Description=%(Pack_Description)s,
-                    Hierarchy1=%(Hierarchy1)s,
-                    Hierarchy2=%(Hierarchy2)s,
-                    Hierarchy3=%(Hierarchy3)s,
-                    UOP=%(UOP)s,
-                    sSell1=%(sSell1)s,
-                    sSell2=%(sSell2)s,
-                    sSell3=%(sSell3)s,
-                    sSell4=%(sSell4)s,
-                    sSell5=%(sSell5)s,
-                    pack1=%(pack1)s,
-                    pack2=%(pack2)s,
-                    pack3=%(pack3)s,
-                    pack4=%(pack4)s,
-                    pack5=%(pack5)s,
-                    EAN=%(EAN)s
-                WHERE item=%(item)s OR EAN=%(EAN)s
-                """,
-                row
-            )
-    conn.commit()
-    cur.close()
-    conn.close()
+def update_products() -> dict:
+    meta = make_meta("info", "Product update from big_data.csv started")
+    return {"meta": meta, "data": {
+        "prompt": "We POST a CSV to this endpoint"
+    }}

--- a/app/utils/make_meta.py
+++ b/app/utils/make_meta.py
@@ -1,0 +1,15 @@
+import os
+import time
+from app import __version__
+
+def make_meta(severity: str, title: str) -> dict:
+    """Create a standard meta dictionary for API responses."""
+    base_url = os.getenv("BASE_URL", "http://localhost:8000")
+    epoch = int(time.time() * 1000)
+    return {
+        "severity": severity,
+        "title": title,
+        "version": __version__,
+        "base_url": base_url,
+        "time": epoch,
+    }

--- a/tests/test_make_meta.py
+++ b/tests/test_make_meta.py
@@ -1,0 +1,27 @@
+import os
+import re
+import time
+import pytest
+from app.utils.make_meta import make_meta
+from app import __version__
+
+def test_make_meta_basic(monkeypatch):
+    monkeypatch.setenv("BASE_URL", "http://testserver:9000")
+    before = int(time.time() * 1000)
+    meta = make_meta("info", "Test Title")
+    after = int(time.time() * 1000)
+    assert meta["severity"] == "info"
+    assert meta["title"] == "Test Title"
+    assert meta["version"] == __version__
+    assert meta["base_url"] == "http://testserver:9000"
+    assert before <= meta["time"] <= after
+
+def test_make_meta_default_base_url(monkeypatch):
+    monkeypatch.delenv("BASE_URL", raising=False)
+    meta = make_meta("success", "Default URL")
+    assert meta["base_url"] == "http://localhost:8000"
+
+def test_make_meta_time_is_int():
+    meta = make_meta("info", "Time Test")
+    assert isinstance(meta["time"], int)
+    assert re.match(r"^\d{13}$", str(meta["time"]))


### PR DESCRIPTION
Introduce app.utils.make_meta to centralize creation of response metadata (severity, title, version, base_url, time). Replace duplicated inline meta dicts in app/api/products/products.py and app/api/products/update.py with calls to make_meta. Simplify the update endpoint to return a placeholder indicating CSV upload handling (previous CSV-processing logic was removed). Add tests/tests_make_meta.py to validate meta fields, default BASE_URL, and timestamp format. These changes DRY up metadata creation and make it easier to test and maintain.