### PR TITLE
Bump version; restructure /prospects/init response

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """NX AI - FastAPI/Python/Postgres/tsvector"""
 
 # Current Version
-__version__ = "1.1.6"
+__version__ = "1.1.7"

--- a/app/api/prospects/prospects.py
+++ b/app/api/prospects/prospects.py
@@ -10,18 +10,16 @@ base_url = os.getenv("BASE_URL", "http://localhost:8000")
 
 @router.get("/prospects")
 def root() -> dict:
-    """Return a placeholder message for prospects endpoint."""
+    """GET /prospects endpoint."""
     meta = make_meta("success", "Prospects placeholder")
     data = {"init": f"{base_url}/prospects/init"}
     return {"meta": meta, "data": data}
 
-
-# New endpoint: /prospects/init
-
+# endpoint: /prospects/init
 @router.get("/prospects/init")
 def prospects_init() -> dict:
     """Initialize prospects and return real total count."""
-    meta = make_meta("success", "Initialized prospects")
+    meta = make_meta("success", "Init prospects")
     conn_gen = get_db_connection()
     conn = next(conn_gen)
     cur = conn.cursor()
@@ -46,7 +44,9 @@ def prospects_init() -> dict:
             return text.strip('-')
 
         title = [
-            {"label": f"{t[0]} ({t[1]})", "value": slugify(t[0])} for t in title_rows if t[0] is not None
+            {"label": str(t[0]), "value": slugify(t[0])}
+            for t in title_rows
+            if t[0] is not None and str(t[0]).strip() != "" and slugify(t[0]) != ""
         ]
         total_unique_title = len(title)
 
@@ -54,7 +54,9 @@ def prospects_init() -> dict:
         cur.execute('SELECT seniority, COUNT(*) FROM prospects WHERE seniority IS NOT NULL GROUP BY seniority ORDER BY COUNT(*) DESC;')
         seniority_rows = cur.fetchall()
         seniority = [
-            {"label": f"{s[0]} ({s[1]})", "value": slugify(s[0])} for s in seniority_rows if s[0] is not None
+            {"label": str(s[0]), "value": slugify(s[0])}
+            for s in seniority_rows
+            if s[0] is not None and str(s[0]).strip() != "" and slugify(s[0]) != ""
         ]
         total_unique_seniority = len(seniority)
 
@@ -62,7 +64,9 @@ def prospects_init() -> dict:
         cur.execute('SELECT sub_departments, COUNT(*) FROM prospects WHERE sub_departments IS NOT NULL GROUP BY sub_departments ORDER BY COUNT(*) DESC;')
         sub_department_rows = cur.fetchall()
         sub_departments = [
-            {"label": f"{sd[0]} ({sd[1]})", "value": slugify(sd[0])} for sd in sub_department_rows if sd[0] is not None
+            {"label": str(sd[0]), "value": slugify(sd[0])}
+            for sd in sub_department_rows
+            if sd[0] is not None and str(sd[0]).strip() != "" and slugify(sd[0]) != ""
         ]
         total_unique_sub_departments = len(sub_departments)
     except Exception:
@@ -77,18 +81,20 @@ def prospects_init() -> dict:
         cur.close()
         conn.close()
     data = {
-        "total_prospects": total,
-        "title": {
-            "total_unique": total_unique_title,
-            "values": title[:3]
+        "total": total,
+        "groups": { 
+            "level": {
+                "total": total_unique_seniority,
+                "list": seniority
+            },
+            "job": {
+                "total": total_unique_title,
+                "list": title
+            },
+            "lane": {
+                "total": total_unique_sub_departments,
+                "list": sub_departments
+            }
         },
-        "seniority": {
-            "total_unique": total_unique_seniority,
-            "values": seniority[:3]
-        },
-        "departments": {
-            "total_unique": total_unique_sub_departments,
-            "values": sub_departments[:3]
-        }
     }
     return {"meta": meta, "data": data}


### PR DESCRIPTION
Bump package version to 1.1.7 and refactor the /prospects/init endpoint response. Replace previous title/seniority/department sections (with label including counts and top-3 truncation) with a unified "groups" object containing level/job/lane entries (each has total and full list). Labels now use string values (no embedded counts) and rows filter out empty values and empty slugs. Minor docstring/meta text tweaks for endpoints.