### PR TITLE
Update meta, prospects endpoints, and CORS origins

### DIFF
--- a/app/api/prospects/prospects.py
+++ b/app/api/prospects/prospects.py
@@ -11,10 +11,10 @@ base_url = os.getenv("BASE_URL", "http://localhost:8000")
 @router.get("/prospects")
 def root() -> dict:
     """GET /prospects endpoint."""
-    meta = make_meta("success", "Prospects start")
+    meta = make_meta("success", "Prospects endpoint")
     data = [
         {"init": f"{base_url}/prospects/init"},
-        {"search": f"{base_url}/prospects/search/?query=example"},
+        {"search": f"{base_url}/prospects/search/?query=karen"},
     ]
     return {"meta": meta, "data": data}
 
@@ -189,6 +189,7 @@ def prospects_init() -> dict:
                 "list": sub_departments
             }
         },
+        "message": "This is a placeholder for prospects/init."
     }
     return {"meta": meta, "data": data}
 

--- a/app/api/root.py
+++ b/app/api/root.py
@@ -13,23 +13,15 @@ def root() -> dict:
     base_url = os.getenv("BASE_URL", "http://localhost:8000")
     epoch = int(time.time() * 1000)
     meta = {
-        "title": "How can I help?",
+        "title": "NX-AI",
         "severity": "success",
         "version": __version__,
         "endpoint": base_url,
         "time": epoch,
     }
     endpoints = [
+        {"name": "docs", "url": f"{base_url}/docs"},
         {"name": "health", "url": f"{base_url}/health"},
         {"name": "prospects", "url": f"{base_url}/prospects"},
-        # {
-        #     "name": "products",
-        #     "url": f"{base_url}/products",
-        #     "children": [
-        #         {"name": "seed", "url": f"{base_url}/products/seed"},
-        #         {"name": "update", "url": f"{base_url}/products/update"}
-        #     ]
-        # },
-        {"name": "docs", "url": f"{base_url}/docs"},
     ]
     return {"meta": meta, "data": endpoints}

--- a/app/main.py
+++ b/app/main.py
@@ -18,8 +18,7 @@ app.add_middleware(
     allow_origins=[
         "http://localhost:1999", 
         "https://goldlabel.pro",
-        "https://soho.goldlabel.pro",
-        "https://echopay.goldlabel.pro",
+        "https://free.goldlabel.pro",
     ],
     allow_credentials=True,
     allow_methods=["*"],

--- a/app/utils/make_meta.py
+++ b/app/utils/make_meta.py
@@ -11,5 +11,8 @@ def make_meta(severity: str, title: str) -> dict:
         "title": title,
         "version": __version__,
         "endpoint": f"{base_url}/prospects",
+        "base": base_url,
+        "base_url": base_url,
+        "message": title,
         "time": epoch,
     }

--- a/tests/test_make_meta.py
+++ b/tests/test_make_meta.py
@@ -13,13 +13,13 @@ def test_make_meta_basic(monkeypatch):
     assert meta["severity"] == "info"
     assert meta["title"] == "Test Title"
     assert meta["version"] == __version__
-    assert meta["base_url"] == "http://testserver:9000"
+    assert meta["base"] == "http://testserver:9000"
     assert before <= meta["time"] <= after
 
 def test_make_meta_default_base_url(monkeypatch):
     monkeypatch.delenv("BASE_URL", raising=False)
     meta = make_meta("success", "Default URL")
-    assert meta["base_url"] == "http://localhost:8000"
+    assert meta["base"] == "http://localhost:8000"
 
 def test_make_meta_time_is_int():
     meta = make_meta("info", "Time Test")


### PR DESCRIPTION
Adjust API metadata and endpoints, update CORS origins, and align tests.

- Change root meta title to "NX-AI" and surface a docs endpoint in the root listing (remove commented products block).
- Update /prospects root message and sample search query; add a placeholder "message" to prospects_init response.
- Extend make_meta to include "base", "base_url", and "message" fields (endpoint now points to /prospects).
- Modify allowed CORS origins (replace soho/echopay with free.goldlabel.pro).
- Update tests to expect the new "base" key in make_meta.