### PR TITLE
Add prompts endpoint and rename prospect groups

### DIFF
--- a/app/api/prompts/__init__.py
+++ b/app/api/prompts/__init__.py
@@ -1,0 +1,3 @@
+"""Prompts Routes"""
+
+from .prompts import router as prompts_router

--- a/app/api/prompts/prompts.py
+++ b/app/api/prompts/prompts.py
@@ -1,0 +1,18 @@
+
+from app import __version__
+import os
+from app.utils.make_meta import make_meta
+from fastapi import APIRouter, Query, Path
+from app.utils.db import get_db_connection
+
+router = APIRouter()
+base_url = os.getenv("BASE_URL", "http://localhost:8000")
+
+@router.get("/prompts")
+def root() -> dict:
+    """GET /prospects endpoint."""
+    meta = make_meta("success", "Prompts endpoint")
+    data = [
+        {"init": f"{base_url}/prompts"},
+    ]
+    return {"meta": meta, "data": data}

--- a/app/api/prospects/prospects.py
+++ b/app/api/prospects/prospects.py
@@ -176,15 +176,15 @@ def prospects_init() -> dict:
     data = {
         "total": total,
         "groups": { 
-            "level": {
+            "seniority": {
                 "total": total_unique_seniority,
                 "list": seniority
             },
-            "job": {
+            "title": {
                 "total": total_unique_title,
                 "list": title
             },
-            "lane": {
+            "sub_departments": {
                 "total": total_unique_sub_departments,
                 "list": sub_departments
             }

--- a/app/api/root.py
+++ b/app/api/root.py
@@ -22,6 +22,7 @@ def root() -> dict:
     endpoints = [
         {"name": "docs", "url": f"{base_url}/docs"},
         {"name": "health", "url": f"{base_url}/health"},
+        {"name": "prompts", "url": f"{base_url}/prompts"},
         {"name": "prospects", "url": f"{base_url}/prospects"},
     ]
     return {"meta": meta, "data": endpoints}

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -12,8 +12,7 @@ router = APIRouter()
 
 from app.api.root import router as root_router
 from app.api.health import router as health_router
-
-
+from app.api.prompts.prompts import router as prompts_router
 from app.api.prospects.prospects import router as prospects_router
 from app.api.prospects.database.alter import router as prospects_alter_router
 from app.api.prospects.database.seed import router as prospects_seed_router
@@ -22,6 +21,7 @@ from app.api.prospects.database.process import router as prospects_process_route
 
 router.include_router(root_router)
 router.include_router(health_router)
+router.include_router(prompts_router)
 router.include_router(prospects_router)
 router.include_router(prospects_alter_router)
 router.include_router(prospects_seed_router)


### PR DESCRIPTION
Introduce a new prompts API: add app/api/prompts/prompts.py and its package init, exposing GET /prompts that returns basic meta and an init link. Register the prompts router in app/api/routes.py and expose the endpoint in the root endpoints list. Also rename groups in prospects response for clearer domain semantics: "level" -> "seniority", "job" -> "title", and "lane" -> "sub_departments".