### PR TITLE
Add prompts table migration and endpoint checks

### DIFF
--- a/app/api/prompts/create_prompts_table.py
+++ b/app/api/prompts/create_prompts_table.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+from app.utils.db import get_db_connection_direct
+
+def run_create_prompts_table_sql():
+    sql_path = os.path.join(os.path.dirname(__file__), "create_prompts_table.sql")
+    with open(sql_path, "r") as f:
+        sql = f.read()
+    conn = get_db_connection_direct()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            conn.commit()
+        print("prompts table created or already exists.")
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    run_create_prompts_table_sql()

--- a/app/api/prompts/create_prompts_table.sql
+++ b/app/api/prompts/create_prompts_table.sql
@@ -1,0 +1,9 @@
+-- Migration: Create prompts table
+CREATE TABLE IF NOT EXISTS prompts (
+    id SERIAL PRIMARY KEY,
+    prompt TEXT NOT NULL,
+    response TEXT NOT NULL,
+    duration_ms INTEGER NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    llm VARCHAR(128) NOT NULL
+);

--- a/app/api/prompts/prompts.py
+++ b/app/api/prompts/prompts.py
@@ -1,5 +1,6 @@
 
 from app import __version__
+
 import os
 from app.utils.make_meta import make_meta
 from fastapi import APIRouter, Query, Path
@@ -10,9 +11,38 @@ base_url = os.getenv("BASE_URL", "http://localhost:8000")
 
 @router.get("/prompts")
 def root() -> dict:
-    """GET /prospects endpoint."""
-    meta = make_meta("success", "Prompts endpoint")
-    data = [
-        {"init": f"{base_url}/prompts"},
-    ]
-    return {"meta": meta, "data": data}
+    """GET /prompts endpoint."""
+    from fastapi import status
+    meta = None
+    data = []
+    # Check if 'prompts' table exists
+    from app.utils.db import get_db_connection_direct
+    conn = get_db_connection_direct()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables 
+                    WHERE table_name = 'prompts'
+                );
+            """)
+            result = cur.fetchone()
+            exists = result[0] if result else False
+    finally:
+        conn.close()
+    if not exists:
+        meta = make_meta("warning", "Table 'prompts' does not exist.")
+        # Do not include 'kata' key or any other keys in data
+        response = {"meta": meta}
+    else:
+        meta = make_meta("success", "Prompts endpoint")
+        # Example: include 'kata' key only if table exists (add as needed)
+        data = [
+            {"init": f"{base_url}/prompts", "kata": "example"},
+        ]
+        response = {"meta": meta, "data": data}
+    # Remove 'kata' key from all items in data if table does not exist
+    if not exists:
+        for item in data:
+            item.pop('kata', None)
+    return response

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -1,3 +1,12 @@
+def get_db_connection_direct():
+    """Create and return a PostgreSQL connection (not a generator)."""
+    return psycopg2.connect(
+        host=os.getenv('DB_HOST'),
+        port=os.getenv('DB_PORT', '5432'),
+        dbname=os.getenv('DB_NAME'),
+        user=os.getenv('DB_USER'),
+        password=os.getenv('DB_PASSWORD'),
+    )
 import os
 import psycopg2
 from dotenv import load_dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest>=8.1.0
 python-dotenv>=1.0.0
 psycopg2-binary>=2.9.0
 python-multipart>=0.0.20
+Faker>=25.2.0


### PR DESCRIPTION
Add SQL migration and runner for a new prompts table (create_prompts_table.sql + create_prompts_table.py). Update prompts endpoint to check for the existence of the prompts table and return a warning meta when the table is missing (conditional data/kata inclusion). Provide a direct DB connection helper get_db_connection_direct in app/utils/db.py for migration/utility use. Also add Faker to requirements.