### PR TITLE
Add script to reset prospects hide flags

### DIFF
--- a/app/api/prospects/database/reset_hide.py
+++ b/app/api/prospects/database/reset_hide.py
@@ -1,0 +1,20 @@
+# Script to reset all 'hide' values to false in the prospects table
+from app.utils.db import get_db_connection
+
+def reset_hide():
+    conn_gen = get_db_connection()
+    conn = next(conn_gen)
+    cur = conn.cursor()
+    try:
+        cur.execute("UPDATE prospects SET hide = FALSE;")
+        conn.commit()
+        print("All 'hide' values reset to FALSE.")
+    except Exception as e:
+        print(f"Error: {e}")
+        conn.rollback()
+    finally:
+        cur.close()
+        conn.close()
+
+if __name__ == "__main__":
+    reset_hide()


### PR DESCRIPTION
Add app/api/prospects/database/reset_hide.py: a standalone script that sets all prospects.hide values to FALSE. It obtains a DB connection via get_db_connection(), executes an UPDATE, commits on success, rolls back on error, and ensures cursor/connection are closed. Includes a __main__ guard for direct execution.