### PR TITLE
Refactor resend email util and simplify endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ## ![Python](/app/static/repoicon.png) Python
 
-> Python with FastAPI using Postgres & tsvector. 
+> With FastAPI using Postgres & tsvector. 
 
-Open Source, production ready Python FastAPI/Postgres app. 
+Open Source, production ready Python FastAPI/Postgres app.  
+
 [GitHub](https://github.com/goldlabelapps/python) | 
-[onrender](https://nx-ai.onrender.com) | 
+[onr]Render](https://nx-ai.onrender.com) | 
 [by Goldlabel](https://goldlabel.pro)
 
 - **Python 3.11+**

--- a/app/api/resend/resend.py
+++ b/app/api/resend/resend.py
@@ -4,7 +4,7 @@ import os
 from app.utils.make_meta import make_meta
 from fastapi import APIRouter, Query, Path, Body, HTTPException
 from app.utils.db import get_db_connection
-from .utils.send_email import send_email_resend
+from app.utils.send_email import send_email_resend
 
 router = APIRouter()
 base_url = os.getenv("BASE_URL", "http://localhost:8000")
@@ -18,10 +18,7 @@ def root() -> dict:
         meta = make_meta("error", "RESEND_API_KEY is missing from environment. Please set it in your .env file.")
         return {"meta": meta}
     meta = make_meta("success", "Resend endpoint")
-    data = [
-        {"action": "send email"},
-    ]
-    return {"meta": meta, "data": data}
+    return {"meta": meta}
 
 
 # POST endpoint to send email

--- a/app/utils/send_email.py
+++ b/app/utils/send_email.py
@@ -2,14 +2,14 @@
 import httpx
 import os
 
+RESEND_API_KEY = os.getenv("RESEND_API_KEY")
 RESEND_API_URL = "https://api.resend.com/emails"
 
 def send_email_resend(to: str, subject: str, html: str, sender: str) -> dict:
-    resend_api_key = os.getenv("RESEND_API_KEY")
-    if not resend_api_key:
+    if not RESEND_API_KEY:
         return {"error": "Missing RESEND_API_KEY"}
     headers = {
-        "Authorization": f"Bearer {resend_api_key}",
+        "Authorization": f"Bearer {RESEND_API_KEY}",
         "Content-Type": "application/json"
     }
     payload = {


### PR DESCRIPTION
Move resend email helper from app/api/resend/utils to app/utils, use a module-level RESEND_API_KEY env var, and update the Authorization header to use it. Update import in resend endpoint to the new path and simplify the root response to only return meta. Also apply minor README wording and link fixes.