### PR TITLE
Use official Resend SDK and remove sender field

### DIFF
--- a/app/api/resend/resend.py
+++ b/app/api/resend/resend.py
@@ -29,7 +29,6 @@ class EmailRequest(BaseModel):
     to: EmailStr
     subject: str
     html: str
-    sender: EmailStr
 
 @router.post("/resend", status_code=status.HTTP_202_ACCEPTED)
 def send_email(request: EmailRequest):
@@ -40,8 +39,7 @@ def send_email(request: EmailRequest):
     result = send_email_resend(
         to=request.to,
         subject=request.subject,
-        html=request.html,
-        sender=request.sender
+        html=request.html
     )
     if "error" in result:
         meta = make_meta("error", result["error"])

--- a/app/utils/send_email.py
+++ b/app/utils/send_email.py
@@ -1,26 +1,20 @@
-# Utility to send email using Resend API
-import httpx
+# Utility to send email using official Resend package
 import os
+import resend
 
-RESEND_API_KEY = os.getenv("RESEND_API_KEY")
-RESEND_API_URL = "https://api.resend.com/emails"
+resend.api_key = os.environ.get("RESEND_API_KEY")
 
-def send_email_resend(to: str, subject: str, html: str, sender: str) -> dict:
-    if not RESEND_API_KEY:
+def send_email_resend(to: str, subject: str, html: str) -> dict:
+    if not resend.api_key:
         return {"error": "Missing RESEND_API_KEY"}
-    headers = {
-        "Authorization": f"Bearer {RESEND_API_KEY}",
-        "Content-Type": "application/json"
-    }
-    payload = {
-        "from": sender,
+    params: resend.Emails.SendParams = {
+        "from": "NX <nx@goldlabel.pro>",
         "to": [to],
         "subject": subject,
-        "html": html
+        "html": html,
     }
     try:
-        response = httpx.post(RESEND_API_URL, headers=headers, json=payload, timeout=10)
-        response.raise_for_status()
-        return response.json()
+        email: resend.Emails.SendResponse = resend.Emails.send(params)
+        return dict(email)
     except Exception as e:
         return {"error": str(e)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+pydantic[email]>=2.0.0
+resend>=0.7.0
 fastapi>=0.110.0
 uvicorn[standard]>=0.29.0
 httpx>=0.27.0
@@ -6,4 +8,3 @@ python-dotenv>=1.0.0
 psycopg2-binary>=2.9.0
 python-multipart>=0.0.20
 Faker>=25.2.0
-pydantic[email]>=2.0.0


### PR DESCRIPTION
Switch email sending to the official resend package and simplify the API. Removed the sender field from EmailRequest and the send_email call; send_email_resend now reads RESEND_API_KEY from the resend client, uses resend.Emails.send with a default from address ("NX <nx@goldlabel.pro>"), and returns the SDK response as a dict. Updated requirements to add resend and pydantic[email]. Error handling still returns an error dict on exceptions.