### PR TITLE
Bump version to 2.0.8 and remove stale files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:system"
-}

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """Python - FastAPI, Postgres, tsvector"""
 
 # Current Version
-__version__ = "2.0.7"
+__version__ = "2.0.8"

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,1 +1,0 @@
-"""NX AI Python package"""


### PR DESCRIPTION
Update package version from 2.0.7 to 2.0.8. Remove workspace-specific .vscode/settings.json and delete app/api/__init__.py (obsolete module). These changes clean up editor config and remove a deprecated package init.