### PR TITLE
Bump version, tweak CI, and trim README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: 🍴 I TEST
 
 on:
-  push:
-    branches: ["master", "staging"]
   pull_request:
     branches: ["master", "staging"]
 jobs:
@@ -22,3 +20,6 @@ jobs:
       - name: 🧪 Run tests
         run: |
           python -m unittest discover -s tests
+
+      - name: Friendly message - End
+        run: echo "✅ All done"    

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Python FastAPI/Postgres App
+## Python 
 
 > Production-ready, open-source FastAPI application with PostgreSQL and blazing-fast full-text search.
 
@@ -64,29 +64,6 @@ SELECT * FROM prospects WHERE search_vector @@ plainto_tsquery('english', 'searc
 ## Processing Large CSV Files
 
 The `/prospects/process` endpoint supports robust ingestion of large CSVs (e.g., 1300+ rows, 300KB+), following the same normalization and insertion pattern as `/prospects/seed` but optimized for scale.
-
-
-## Directory Structure
-
-```
-app/
-	main.py           # FastAPI entrypoint
-	api/              # API endpoints & schemas
-		health.py
-		root.py
-		routes.py
-		products/
-		prompts/
-		prospects/
-		resend/
-		utils/
-	static/           # Static assets (e.g., repoicon.png)
-	utils/            # Utility scripts
-tests/              # Pytest test suite
-requirements.txt    # Python dependencies
-render.yaml         # Deployment config (Render.com)
-```
-
 
 ## Contributing
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """Python - FastAPI, Postgres, tsvector"""
 
 # Current Version
-__version__ = "2.1.3"
+__version__ = "2.1.4"


### PR DESCRIPTION
Bump package version to 2.1.4 (app/__init__.py). Update CI workflow (.github/workflows/ci.yml): remove push trigger for master/staging so workflow runs only on pull_request, and add a final friendly message step after tests. Simplify README header and remove the directory structure section to shorten documentation.