### PR TITLE
Update email sender and adjust endpoint tests

### DIFF
--- a/app/utils/send_email.py
+++ b/app/utils/send_email.py
@@ -8,7 +8,7 @@ def send_email_resend(to: str, subject: str, html: str) -> dict:
     if not resend.api_key:
         return {"error": "Missing RESEND_API_KEY"}
     params: resend.Emails.SendParams = {
-        "from": "NX <nx@goldlabel.pro>",
+        "from": "NX° <nx@goldlabel.pro>",
         "to": [to],
         "subject": subject,
         "html": html,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -13,12 +13,7 @@ def test_health_endpoint():
     assert response.json() == {"status": "ok"}
 
 def test_health_meta_keys():
+    # The /health endpoint now only returns {"status": "ok"}
     response = client.get("/health")
-    data = response.json()
-    if "meta" in data:
-        meta = data["meta"]
-        for key in ["severity", "title", "version", "base_url", "time"]:
-            assert key in meta
-    else:
-        # Legacy: no meta, just status
-        assert data == {"status": "ok"}
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -28,13 +28,17 @@ client = TestClient(app)
 
 
 def test_llm_get_endpoint():
-    response = client.get("/llm")
+    api_key = os.getenv("PYTHON_KEY", "test")
+    response = client.get("/llm", headers={"X-API-Key": api_key})
     assert response.status_code == 200
     data = response.json()
     assert "meta" in data
     assert data["meta"]["severity"] == "success"
     assert "LLM" in data["meta"]["title"]
     assert "records" in data["meta"]["title"]
+    assert "data" in data
+    assert "data" in data["data"]
+    assert isinstance(data["data"]["data"], list)
 
 
 def test_llm_post_endpoint(monkeypatch):
@@ -51,8 +55,9 @@ def test_llm_post_endpoint(monkeypatch):
 
     monkeypatch.setattr("google.genai.Client", lambda *args, **kwargs: MockGenAIClient())
 
+    api_key = os.getenv("PYTHON_KEY", "test")
     payload = {"prompt": "Test prompt"}
-    response = client.post("/llm", json=payload)
+    response = client.post("/llm", json=payload, headers={"X-API-Key": api_key})
     assert response.status_code == 200
     data = response.json()
     assert "meta" in data

--- a/tests/test_prospects.py
+++ b/tests/test_prospects.py
@@ -9,12 +9,12 @@ def test_get_prospects_root():
     assert response.status_code == 200
     data = response.json()
     assert "meta" in data
+    assert "pagination" in data
     assert "data" in data
     assert isinstance(data["data"], list)
     # Check that the expected keys are present in the data list (if not empty)
     if data["data"]:
         first_item = data["data"][0]
-        # Adjust these keys to match your actual prospect schema
         assert "id" in first_item
         assert "first_name" in first_item or "last_name" in first_item
     # Meta checks
@@ -27,5 +27,6 @@ def test_prospects_returns_list():
     assert response.status_code == 200
     data = response.json()
     assert "meta" in data
+    assert "pagination" in data
     assert "data" in data
-    assert isinstance(data["data"], list) or isinstance(data["data"], dict)
+    assert isinstance(data["data"], list)

--- a/tests/test_resend.py
+++ b/tests/test_resend.py
@@ -1,0 +1,26 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_resend_post_email(monkeypatch):
+    """Test POST /resend actually sends an email if RESEND_API_KEY is set."""
+    resend_api_key = os.getenv("RESEND_API_KEY")
+    if not resend_api_key:
+        pytest.skip("RESEND_API_KEY not set; skipping real email test.")
+
+    payload = {
+        "to": 'listingslab@gmail.com',
+        "subject": "Python pytest",
+        "html": "Python tests have run"
+    }
+    response = client.post("/resend", json=payload)
+    assert response.status_code == 202
+    data = response.json()
+    assert "meta" in data
+    assert data["meta"]["severity"] == "success"
+    assert "Email sent successfully" in data["meta"]["title"]
+    assert "data" in data
+    assert "id" in data["data"] or "object" in data["data"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
-from app.api.routes import get_db_connection
 from app.main import app
 
 client = TestClient(app)
@@ -21,4 +20,5 @@ def test_health_returns_ok() -> None:
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
 


### PR DESCRIPTION
Change the Resend email 'from' display name to "NX°" and update tests to match recent API behavior: simplify /health response assertions, require X-API-Key header and stricter data structure checks for /llm, assert pagination and list-type responses for prospects endpoints, and add an integration-style test for /resend that runs only when RESEND_API_KEY is present. Also minor cleanup in route tests imports/formatting.