### PR TITLE
Add migrations to drop and rename prospect columns

### DIFF
--- a/app/api/prospects/sql/alter_drop_primary_email_verification_source.sql
+++ b/app/api/prospects/sql/alter_drop_primary_email_verification_source.sql
@@ -1,0 +1,2 @@
+-- Migration: Remove primary_email_verification_source column from prospects table
+ALTER TABLE prospects DROP COLUMN IF EXISTS primary_email_verification_source;

--- a/app/api/prospects/sql/alter_rename_corporate_phone_to_phone.sql
+++ b/app/api/prospects/sql/alter_rename_corporate_phone_to_phone.sql
@@ -1,0 +1,2 @@
+-- Migration: Rename corporate_phone column to phone in prospects table
+ALTER TABLE prospects RENAME COLUMN corporate_phone TO phone;

--- a/app/api/prospects/sql/run_alter_drop_primary_email_verification_source.py
+++ b/app/api/prospects/sql/run_alter_drop_primary_email_verification_source.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+from app.utils.db import get_db_connection_direct
+
+if __name__ == "__main__":
+    sql = "ALTER TABLE prospects DROP COLUMN IF EXISTS primary_email_verification_source;"
+    conn = get_db_connection_direct()
+    cur = conn.cursor()
+    cur.execute(sql)
+    conn.commit()
+    cur.close()
+    conn.close()
+    print("Migration complete: primary_email_verification_source column dropped from prospects table.")

--- a/app/api/prospects/sql/run_alter_rename_corporate_phone_to_phone.py
+++ b/app/api/prospects/sql/run_alter_rename_corporate_phone_to_phone.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+from app.utils.db import get_db_connection_direct
+
+if __name__ == "__main__":
+    sql = "ALTER TABLE prospects RENAME COLUMN corporate_phone TO phone;"
+    conn = get_db_connection_direct()
+    cur = conn.cursor()
+    cur.execute(sql)
+    conn.commit()
+    cur.close()
+    conn.close()
+    print("Migration complete: corporate_phone column renamed to phone in prospects table.")


### PR DESCRIPTION
Add two SQL migration files to modify the prospects table: drop primary_email_verification_source and rename corporate_phone to phone. Include corresponding Python runner scripts that execute the ALTER statements via get_db_connection_direct, commit the changes, close the connection, and print completion messages.