### PR TITLE
Add migrations to rename prospects columns

### DIFF
--- a/app/api/prospects/sql/alter_rename_company_name_to_company.sql
+++ b/app/api/prospects/sql/alter_rename_company_name_to_company.sql
@@ -1,0 +1,2 @@
+-- Migration: Rename company_name column to company in prospects table
+ALTER TABLE prospects RENAME COLUMN company_name TO company;

--- a/app/api/prospects/sql/alter_rename_primary_email_last_verified_at_to_sell_by_date.sql
+++ b/app/api/prospects/sql/alter_rename_primary_email_last_verified_at_to_sell_by_date.sql
@@ -1,0 +1,2 @@
+-- Migration: Rename primary_email_last_verified_at column to sell_by_date in prospects table
+ALTER TABLE prospects RENAME COLUMN primary_email_last_verified_at TO sell_by_date;

--- a/app/api/prospects/sql/alter_rename_primary_email_source_to_source.sql
+++ b/app/api/prospects/sql/alter_rename_primary_email_source_to_source.sql
@@ -1,0 +1,2 @@
+-- Migration: Rename primary_email_source column to source in prospects table
+ALTER TABLE prospects RENAME COLUMN primary_email_source TO source;

--- a/app/api/prospects/sql/run_alter_rename_company_name_to_company.py
+++ b/app/api/prospects/sql/run_alter_rename_company_name_to_company.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+from app.utils.db import get_db_connection_direct
+
+if __name__ == "__main__":
+    sql = "ALTER TABLE prospects RENAME COLUMN company_name TO company;"
+    conn = get_db_connection_direct()
+    cur = conn.cursor()
+    cur.execute(sql)
+    conn.commit()
+    cur.close()
+    conn.close()
+    print("Migration complete: company_name column renamed to company in prospects table.")

--- a/app/api/prospects/sql/run_alter_rename_primary_email_last_verified_at_to_sell_by_date.py
+++ b/app/api/prospects/sql/run_alter_rename_primary_email_last_verified_at_to_sell_by_date.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+from app.utils.db import get_db_connection_direct
+
+if __name__ == "__main__":
+    sql = "ALTER TABLE prospects RENAME COLUMN primary_email_last_verified_at TO sell_by_date;"
+    conn = get_db_connection_direct()
+    cur = conn.cursor()
+    cur.execute(sql)
+    conn.commit()
+    cur.close()
+    conn.close()
+    print("Migration complete: primary_email_last_verified_at column renamed to sell_by_date in prospects table.")

--- a/app/api/prospects/sql/run_alter_rename_primary_email_source_to_source.py
+++ b/app/api/prospects/sql/run_alter_rename_primary_email_source_to_source.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+from app.utils.db import get_db_connection_direct
+
+if __name__ == "__main__":
+    sql = "ALTER TABLE prospects RENAME COLUMN primary_email_source TO source;"
+    conn = get_db_connection_direct()
+    cur = conn.cursor()
+    cur.execute(sql)
+    conn.commit()
+    cur.close()
+    conn.close()
+    print("Migration complete: primary_email_source column renamed to source in prospects table.")


### PR DESCRIPTION
Add three SQL migration files and corresponding Python runner scripts under app/api/prospects/sql to rename columns on the prospects table. Renames: company_name -> company, primary_email_last_verified_at -> sell_by_date, and primary_email_source -> source. The Python scripts use app.utils.db.get_db_connection_direct to execute the ALTER TABLE statements and print a completion message.