### PR TITLE
Bump version; update LinkedIn response and CORS

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """Python - FastAPI, Postgres, tsvector"""
 
 # Current Version
-__version__ = "2.2.3"
+__version__ = "2.2.4"

--- a/app/api/prompt/linkedin.py
+++ b/app/api/prompt/linkedin.py
@@ -84,13 +84,12 @@ def linkedin_prompt_success(payload: dict, api_key: str = Depends(get_api_key)) 
                 "meta": make_meta("success", "LinkedIn URL already analysed"),
                 "data": {
                     "cached": True,
-                    "id": row[0],
+                    "prompt_id": row[0],
                     "linkedin_url": linkedin_url,
                     "prompt": row[1],
                     "completion": row[2],
                     "time": row[3].isoformat() if row[3] else None,
                     "model": row[4],
-                    "record_data": row[5],
                 },
             }
 

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:1999", 
+        "http://localhost:2027",
         "https://goldlabel.pro",
         "https://free.goldlabel.pro",
     ],


### PR DESCRIPTION
Bump package version to 2.2.4. Modify the cached LinkedIn prompt response payload to expose 'prompt_id' (instead of 'id') and remove the 'record_data' field. Add http://localhost:2027 to the CORS allow_origins list to permit an additional local dev origin.