### PR TITLE
Add PATCH /prompt/drop endpoint

### DIFF
--- a/app/api/prompt/__init__.py
+++ b/app/api/prompt/__init__.py
@@ -1,4 +1,6 @@
 """Prompt Routes"""
 
+
 from .prompt import router as prompt_router
 from .linkedin import router as linkedin_router
+from .drop import router as drop_router

--- a/app/api/prompt/drop.py
+++ b/app/api/prompt/drop.py
@@ -1,0 +1,24 @@
+import os
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.utils.api_key_auth import get_api_key
+from app.utils.db import get_db_connection_direct
+from app.utils.make_meta import make_meta
+
+router = APIRouter()
+
+# PATCH /prompt/drop: empties the prompt table
+@router.patch("/prompt/drop")
+def drop_prompt_table(api_key: str = Depends(get_api_key)) -> dict:
+    """PATCH /prompt/drop: empties the prompt table."""
+    try:
+        conn = get_db_connection_direct()
+        cur = conn.cursor()
+        cur.execute("TRUNCATE TABLE prompt RESTART IDENTITY CASCADE;")
+        conn.commit()
+        cur.close()
+        conn.close()
+        return {"meta": make_meta("success", "Prompt table emptied"), "data": {}}
+    except Exception as e:
+        return {"meta": make_meta("error", f"Failed to empty prompt table: {str(e)}"), "data": {}}

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -10,6 +10,7 @@ from app.utils.health import router as health_router
 from app.utils.notify.resend import router as resend_router
 from app.api.prompt.prompt import router as prompt_router
 from app.api.prompt.linkedin import router as linkedin_router
+from app.api.prompt.drop import router as drop_router
 from app.api.prospects.prospects import router as prospects_router
 from app.api.orders.orders import router as orders_router
 
@@ -18,5 +19,6 @@ router.include_router(resend_router)
 router.include_router(health_router)
 router.include_router(prompt_router)
 router.include_router(linkedin_router)
+router.include_router(drop_router)
 router.include_router(prospects_router)
 router.include_router(orders_router)


### PR DESCRIPTION
Add an admin endpoint to empty the prompt table. Introduces app/api/prompt/drop.py with a PATCH /prompt/drop route that requires API key auth, uses a direct DB connection to TRUNCATE TABLE prompt RESTART IDENTITY CASCADE, commits the change, and returns standardized meta/data responses on success or error. Also register the new router in app/api/prompt/__init__.py and app/api/routes.py so the route is included in the API.