### PR TITLE
Add queue API routes and /queue endpoint

### DIFF
--- a/app/api/queue/__init__.py
+++ b/app/api/queue/__init__.py
@@ -1,0 +1,3 @@
+"""Queue Routes"""
+
+from .queue import router as queue_router

--- a/app/api/queue/queue.py
+++ b/app/api/queue/queue.py
@@ -1,0 +1,15 @@
+import os
+from fastapi import APIRouter, HTTPException, Query, Request, Depends
+from app.utils.make_meta import make_meta
+from app.utils.db import get_db_connection_direct
+from app.utils.api_key_auth import get_api_key
+
+router = APIRouter()
+
+
+@router.get("/queue")
+def read_queue() -> dict:
+    """GET /queue: """
+    return {"meta": make_meta("success", "Hello from queue"), "data": {"do": "it"}}
+
+    

--- a/app/api/root.py
+++ b/app/api/root.py
@@ -22,6 +22,12 @@ def root() -> dict:
     endpoints = [
         {"name": "health", "url": f"{base_url}/health"},
         {
+            "name": "Queue", 
+            "endpoints": [
+                {"name": "list", "url": f"{base_url}/queue"},
+            ]
+        },
+        {
             "name": "Prompt°", 
             "endpoints": [
                 {"name": "list", "url": f"{base_url}/prompt"},

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -13,6 +13,7 @@ from app.api.prompt.linkedin import router as linkedin_router
 from app.api.prompt.drop import router as drop_router
 from app.api.prospects.prospects import router as prospects_router
 from app.api.orders.orders import router as orders_router
+from app.api.queue.queue import router as queue_router
 
 router.include_router(root_router)
 router.include_router(resend_router)
@@ -22,3 +23,4 @@ router.include_router(linkedin_router)
 router.include_router(drop_router)
 router.include_router(prospects_router)
 router.include_router(orders_router)
+router.include_router(queue_router)


### PR DESCRIPTION
Introduce a new queue API module (app/api/queue) with a simple GET /queue endpoint returning a test meta/data payload. Wire the new router into app/api/routes.py and expose the queue entry in the API root listing (app/api/root.py). Prepared imports for DB and API key auth in the new module for future use.