### PR TITLE
Add CTA support to email resend and template

### DIFF
--- a/app/api/notify/resend.py
+++ b/app/api/notify/resend.py
@@ -39,6 +39,16 @@ def root() -> dict:
                     "type": "string",
                     "required": True,
                     "description": "HTML content of the email."
+                },
+                "cta_label": {
+                    "type": "string",
+                    "required": False,
+                    "description": "Optional CTA button label. Defaults to 'Call To Action'."
+                },
+                "cta_url": {
+                    "type": "string",
+                    "required": False,
+                    "description": "Optional CTA URL. Defaults to the website base URL."
                 }
             }
         }
@@ -53,6 +63,8 @@ class EmailRequest(BaseModel):
     to: EmailStr
     subject: str
     html: str
+    cta_label: str | None = None
+    cta_url: str | None = None
 
 @router.post("/resend", status_code=status.HTTP_202_ACCEPTED)
 def send_email(request: EmailRequest):
@@ -63,7 +75,12 @@ def send_email(request: EmailRequest):
     result = send_email_resend(
         to=request.to,
         subject=request.subject,
-        html=goldlabel_email(request.subject, request.html),
+        html=goldlabel_email(
+            request.subject,
+            request.html,
+            cta_label=request.cta_label or "Call To Action",
+            cta_url=request.cta_url or "https://goldlabel.pro",
+        ),
     )
     if "error" in result:
         meta = make_meta("error", result["error"])

--- a/app/utils/email_templates/goldlabel.bak.py
+++ b/app/utils/email_templates/goldlabel.bak.py
@@ -1,31 +1,24 @@
 """Goldlabel branded HTML email template."""
 
 _LOGO_URL = "https://goldlabel.pro/goldlabelpro/png/favicon.png"
-_BASE_URL = "https://goldlabel.pro"
 
 # Palette (dark theme used for the email chrome; body text stays readable on white clients)
 _DARK_BG      = "#364450"
 _DARK_PAPER   = "#364450"
 _DARK_PRIMARY = "#ffd849"
 _DARK_TEXT    = "#ffffff"
-_LIGHT_PAPER  = "#ffffff"
+_LIGHT_BG     = "#eaf0f5"
+_LIGHT_PAPER  = "#EEF7FF"
 _LIGHT_TEXT   = "#000000"
 _LIGHT_PRIMARY = "#364450"
 
 
-def goldlabel_email(
-    subject: str,
-    body_html: str,
-    cta_label: str = "Call To Action",
-    cta_url: str = _BASE_URL,
-) -> str:
+def goldlabel_email(subject: str, body_html: str) -> str:
     """Return a complete HTML email string with Goldlabel branding.
 
     Args:
         subject:   Used as the visible heading inside the email.
         body_html: Inner HTML content placed in the message body area.
-        cta_label: Label rendered in the full-width call-to-action button.
-        cta_url:   Destination URL for the call-to-action button.
 
     Returns:
         A self-contained HTML string ready to pass to send_email_resend().
@@ -47,19 +40,18 @@ def goldlabel_email(
     /* ── Base ──────────────────────────────────────── */
     body {{
       margin: 0; padding: 0;
-      background-color: #ffffff;
+      background-color: {_LIGHT_BG};
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       color: {_LIGHT_TEXT};
     }}
 
     /* ── Dark-mode overrides ───────────────────────── */
     @media (prefers-color-scheme: dark) {{
-      body, .email-wrapper {{ background-color: #ffffff !important; color: {_DARK_TEXT} !important; }}
+      body, .email-wrapper {{ background-color: {_DARK_BG} !important; color: {_DARK_TEXT} !important; }}
       .email-card         {{ background-color: {_DARK_PAPER} !important; color: {_DARK_TEXT} !important; }}
-      .email-header-inner {{ background-color: {_DARK_BG} !important; }}
+      .email-header       {{ background-color: {_DARK_BG} !important; }}
       .email-footer       {{ background-color: {_DARK_BG} !important; color: {_DARK_TEXT} !important; }}
       .email-subject      {{ color: {_DARK_PRIMARY} !important; }}
-      .email-cta          {{ background-color: {_DARK_PRIMARY} !important; color: {_DARK_BG} !important; }}
       a                   {{ color: {_DARK_PRIMARY} !important; }}
     }}
   </style>
@@ -67,78 +59,64 @@ def goldlabel_email(
 <body class="email-wrapper">
   <!-- Outer wrapper -->
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
-         style="padding: 0;">
+         style="background-color:{_LIGHT_BG}; padding: 32px 0;">
     <tr>
       <td align="center">
 
         <!-- Card -->
         <table role="presentation" class="email-card" width="600" cellpadding="0" cellspacing="0"
                style="max-width:600px; width:100%; background-color:{_LIGHT_PAPER};
-             border-radius:6px; overflow:hidden;
-                      box-shadow:none;">
+                      border-radius:8px; overflow:hidden;
+                      box-shadow: 0 2px 8px rgba(0,0,0,0.10);">
 
           <!-- Header -->
           <tr>
-            <td class="email-header" align="left"
-                style="padding:24px 40px 0 40px;">
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="email-header-inner"
-                     style="background-color:{_LIGHT_PRIMARY}; border-radius:6px;">
-                <tr>
-                  <td align="left" valign="middle" style="padding:20px 16px 20px 20px; width:1%; white-space:nowrap;">
-                    <a href="{_BASE_URL}" style="text-decoration:none; display:inline-block;">
-                      <img src="{_LOGO_URL}"
-                           width="48" height="48"
-                           alt="Goldlabel"
-                           style="width:48px; height:48px; border-radius:6px;" />
-                    </a>
-                  </td>
-                  <td align="left" valign="middle" style="padding:20px 20px 20px 0;">
-                    <h1 class="email-subject"
-                        style="margin:0; font-size:22px; font-weight:700;
-                               color:#ffffff; line-height:1.3;">
-                      {subject}
-                    </h1>
-                  </td>
-                </tr>
-              </table>
+            <td class="email-header" align="center"
+                style="background-color:{_DARK_BG}; padding: 28px 40px;">
+              <img src="{_LOGO_URL}"
+                   width="48" height="48"
+                   alt="Goldlabel"
+                   style="width:48px; height:48px; border-radius:8px;" />
+            </td>
+          </tr>
+
+          <!-- Subject banner -->
+          <tr>
+            <td align="left"
+                style="padding: 28px 40px 0 40px;">
+              <h1 class="email-subject"
+                  style="margin:0; font-size:22px; font-weight:700;
+                         color:{_LIGHT_PRIMARY}; line-height:1.3;">
+                {subject}
+              </h1>
             </td>
           </tr>
 
           <!-- Body -->
           <tr>
             <td align="left"
-                style="padding: 30px 40px 24px 40px;
+                style="padding: 20px 40px 32px 40px;
                        font-size:15px; line-height:1.7; color:{_LIGHT_TEXT};">
               {body_html}
             </td>
           </tr>
 
-          <!-- CTA -->
+          <!-- Divider -->
           <tr>
-            <td align="left" style="padding: 0 40px 28px 40px;">
-              <a class="email-cta"
-                 href="{cta_url}"
-                 style="display:block; width:100%; box-sizing:border-box;
-                        background-color:{_LIGHT_PRIMARY}; color:#ffffff;
-                        font-size:16px; font-weight:700; text-align:center;
-                        text-decoration:none; border-radius:6px;
-                        padding:14px 20px;">
-                {cta_label}
-              </a>
+            <td style="padding: 0 40px;">
+              <hr style="border:none; border-top:1px solid {_DARK_PRIMARY}; margin:0;" />
             </td>
           </tr>
-
 
           <!-- Footer -->
           <tr>
             <td class="email-footer" align="center"
                 style="padding: 20px 40px;
                        font-size:12px; color:#666666;">
-              <a href="https://github.com/goldlabelapps/python"
-                 style="color:{_LIGHT_PRIMARY}; text-decoration:none;">
-                 Sent with Python°
-              </a>
-             
+              <a href="https://goldlabel.pro"
+                 style="color:{_LIGHT_PRIMARY}; text-decoration:none;">goldlabel.pro</a>
+              &nbsp;&middot;&nbsp;
+              You received this email because a request was made via the NX° API.
             </td>
           </tr>
 


### PR DESCRIPTION
Expose optional CTA label/url in the resend API and wire them into the HTML template. Updated app/api/notify/resend.py to accept cta_label and cta_url in the request schema and EmailRequest model, and to pass defaults into goldlabel_email. Modified app/utils/email_templates/goldlabel.py to add _BASE_URL, accept cta_label/cta_url parameters, update header/footer/styles, and render a full-width CTA button. Added app/utils/email_templates/goldlabel.bak.py as a backup of the previous template.