### PR TITLE
Bump version and hide prompt/completion fields

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """Python° - FastAPI, Postgres, tsvector"""
 
 # Current Version
-__version__ = "3.0.6"
+__version__ = "3.0.7"

--- a/app/api/prompt/prompt.py
+++ b/app/api/prompt/prompt.py
@@ -41,15 +41,15 @@ def get_prompt_table_metadata(api_key: str = Depends(get_api_key)) -> dict:
         return {
             "meta": meta,
             "data": {
-                "record_count": record_count,
-                "columns": columns,
-                "top_record": {
+                "first_record": {
                     "id": top_row[0],
-                    "prompt": top_row[1],
-                    "completion": top_row[2],
+                    # "prompt": top_row[1],
+                    # "completion": top_row[2],
                     "time": top_row[3].isoformat() if top_row and top_row[3] else None,
                     "model": top_row[4],
                 } if top_row else None,
+                "record_count": record_count,
+                "columns": columns,
             },
         }
     except Exception as e:


### PR DESCRIPTION
Update package version to 3.0.7 and adjust prompt API response. Rename top_record to first_record and comment out the prompt/completion fields (only id, time, and model remain exposed). Also reorder fields so record_count and columns follow first_record. This avoids returning raw prompt/completion content in the metadata endpoint.