### PR TITLE
Bump version and add local CORS origins

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 """Python° - FastAPI, Postgres, tsvector"""
 
 # Current Version
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:1999", 
+        "http://localhost:1998", 
+        "http://localhost:1975", 
         "http://localhost:1980", 
         "http://localhost:2027",
         "http://localhost:2020",


### PR DESCRIPTION
Bump package version from 3.1.2 to 3.1.3 and add two additional local development origins (http://localhost:1998, http://localhost:1975) to CORSMiddleware allow_origins so those ports can access the API during development.